### PR TITLE
Fix curated mapper list and normalization edge cases

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Flexible Automapper for Beatsaber made for any difficulty
 
 ![Screenshot played by RamenBot](https://i.imgur.com/ECXMxY5.jpeg)
 
-Automapper with fully adjustable difficulty (inpsired by star difficulty) ranging from easy maps (< 1) to Expert+++ maps (10+)
+Automapper with fully adjustable difficulty (inspired by star difficulty) ranging from easy maps (< 1) to Expert+++ maps (10+)
 
 Update Jan 2025: App is finally available via Pinokio: https://program.pinokio.computer/#/
 Just got to "Discover" and then "Download from URL": https://github.com/fred-brenner/InfernoSaber-App
@@ -64,7 +64,7 @@ Current pinokio version from: https://github.com/pinokiocomputer/pinokio/release
 
 The inference usage is simplified with the included app in branch 'main_app'. The AI models will be automatically downloaded during runtime from [Hugging Face](https://huggingface.co/BierHerr/InfernoSaber), if not yet available.
 
-You can also train your own models on your favorite maps and difficulty. This can only be done locally with cloning the repo and using GPU (one better consumer GPU is enough) A guide to train the 4 models is included in the repo: 'How_to_Train_InfernoSaber.docx'
+You can also train your own models on your favorite maps and difficulty. This can only be done locally with cloning the repo and using GPU (one better consumer GPU is enough) A guide to train the 4 models is included in the repo: [How to - Linux install for training and app](How%20to%20-%20Linux%20install%20for%20training%20and%20app.md)
 
 Extract maps from Beatsaber/Bsaber to feed them into AI models. Map versions with custom modded data (values out of normal boundaries) are excluded, so that the data is as smooth as possible.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/test_mapper_selection.py
+++ b/tests/test_mapper_selection.py
@@ -1,0 +1,11 @@
+from tools.config.mapper_selection import return_mapper_list
+
+
+def test_curated1_contains_separate_mapper_entries():
+    mapper_list = return_mapper_list('curated1')
+
+    assert 'puds' in mapper_list
+    assert 'Moriik' in mapper_list
+    assert 'pudsMoriik' not in mapper_list
+    assert mapper_list.count('puds') == 1
+    assert mapper_list.count('Moriik') == 1

--- a/tools/config/mapper_selection.py
+++ b/tools/config/mapper_selection.py
@@ -8,8 +8,8 @@ def return_mapper_list(mapper_shortcut):
         mapper_list = ['Nuketime', 'Heisenberg', 'Ruckus',
                        'Joetastic', 'BennyDaBeast', 'Hexagonial',
                        'Ryger', 'Skyler Wallace', 'Uninstaller',
-                       'Teuflum', 'GreatYazer', 'puds'
-                                                'Moriik', 'Ab', 'DE125', 'Skeelie',
+                       'Teuflum', 'GreatYazer', 'puds',
+                       'Moriik', 'Ab', 'DE125', 'Skeelie',
                        'Psyc0pathic', 'Hexagonial', 'Electrostats',
                        'DankruptMemer', 'StyngMe', 'Rustic',
                        'Souk', 'Oddloop', 'Chroma', 'Pendulum',

--- a/tools/utils/numpy_shorts.py
+++ b/tools/utils/numpy_shorts.py
@@ -10,9 +10,17 @@ def np_append(old, new, axis=0):
     return out
 
 
-def minmax_3d(ar: np.array) -> np.array:
-    ar -= ar.min()
-    ar /= ar.max()
+def minmax_3d(ar: np.ndarray) -> np.ndarray:
+    """Normalize an array to the range [0, 1] while avoiding division by zero."""
+    min_val = ar.min()
+    max_val = ar.max()
+    value_range = max_val - min_val
+
+    ar -= min_val
+    if value_range == 0:
+        ar.fill(0)
+    else:
+        ar /= value_range
     return ar
 
 


### PR DESCRIPTION
## Summary
- fix README typo and point training guide reference to the markdown file
- make `minmax_3d` robust for zero-range arrays to prevent NaNs
- correct the curated mapper list, configure pytest, and add a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d199798b0083278b100411e6fbdb1f