### PR TITLE
Refactor configuration into class

### DIFF
--- a/app_helper/check_input.py
+++ b/app_helper/check_input.py
@@ -1,6 +1,7 @@
 import os
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 
 
 bs_folder_name = "Beat Saber_Data/CustomLevels"

--- a/app_helper/set_app_paths.py
+++ b/app_helper/set_app_paths.py
@@ -1,5 +1,6 @@
 from app_helper.update_dir_path import update_dir_path
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 from tools.config.check_folder_structure import check_folder_structure
 
 

--- a/beat_prediction/ai_beat_gen.py
+++ b/beat_prediction/ai_beat_gen.py
@@ -20,7 +20,8 @@ from preprocessing.bs_mapper_pre import load_beat_data
 from training.helpers import test_gpu_tf, filter_by_bps, calc_class_weight
 from training.tensorflow_models import create_music_model
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.utils import numpy_shorts
 from tools.utils.numpy_shorts import reduce_number_of_songs
 

--- a/beat_prediction/beat_prop.py
+++ b/beat_prediction/beat_prop.py
@@ -3,7 +3,8 @@ import numpy as np
 # import matplotlib.pyplot as plt
 # from scipy.ndimage.filters import maximum_filter
 
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 from tools.utils import numpy_shorts
 
 

--- a/beat_prediction/beat_to_lstm.py
+++ b/beat_prediction/beat_to_lstm.py
@@ -1,7 +1,8 @@
 import numpy as np
 # from progressbar import ProgressBar
 
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 from tools.utils import numpy_shorts
 
 

--- a/beat_prediction/find_beats.py
+++ b/beat_prediction/find_beats.py
@@ -4,7 +4,8 @@ import aubio
 import numpy as np
 # import matplotlib.pyplot as plt
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from preprocessing.music_processing import log_specgram
 
 

--- a/bs_shift/cleanup_n_format.py
+++ b/bs_shift/cleanup_n_format.py
@@ -1,7 +1,8 @@
 import json
 import os
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 
 
 def read_json_content_file(file_path: str, filename="") -> list[str]:

--- a/bs_shift/export_map.py
+++ b/bs_shift/export_map.py
@@ -2,7 +2,8 @@ import shutil
 import os
 from pydub import AudioSegment, effects
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 
 
 def shutil_copy_maps(song_name, index="1234_"):

--- a/bs_shift/shift.py
+++ b/bs_shift/shift.py
@@ -18,7 +18,8 @@ from tools.fail_list.black_list import append_fail, delete_fails
 from tools.utils.index_find_str import return_find_str
 
 # set folder paths
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 # import exclusion names
 from tools.config import exclusion
 

--- a/evaluation/evaluate_beat_algorithms.py
+++ b/evaluation/evaluate_beat_algorithms.py
@@ -7,7 +7,8 @@ script_dir = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.abspath(os.path.join(script_dir, ".."))
 sys.path.append(parent_dir)
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 
 # overwrite test path and config
 ################################

--- a/lighting_prediction/generate_lighting.py
+++ b/lighting_prediction/generate_lighting.py
@@ -13,7 +13,8 @@ from map_creation.class_helpers import get_class_size, update_out_class, add_fav
 
 # from preprocessing.music_processing import run_music_preprocessing
 
-# from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 # from tools.utils import numpy_shorts
 
 from training.helpers import *

--- a/lighting_prediction/train_lighting.py
+++ b/lighting_prediction/train_lighting.py
@@ -20,7 +20,8 @@ from lighting_prediction.tf_lighting import create_tf_model
 from preprocessing.beat_data_helper import load_raw_beat_data
 from preprocessing.music_processing import run_music_preprocessing
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 # from tools.utils import numpy_shorts
 
 from training.helpers import test_gpu_tf, filter_by_bps, ai_encode_song, categorical_to_class

--- a/main.py
+++ b/main.py
@@ -7,7 +7,8 @@ import time
 import tensorflow as tf
 # import sys
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 import map_creation.gen_beats as beat_generator
 from bs_shift.export_map import check_music_files, shutil_copy_maps
 

--- a/main_app.py
+++ b/main_app.py
@@ -16,7 +16,8 @@ from app_helper.set_app_paths import set_app_paths
 from app_helper.update_dir_path import update_dir_path
 # from main import main
 from main_multi import main_multi_par
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 from tools.config.mapper_selection import update_model_file_paths
 from tools.utils.huggingface import model_download
 

--- a/main_multi.py
+++ b/main_multi.py
@@ -13,7 +13,8 @@ from functools import partial
 from multiprocessing import Pool, freeze_support
 
 import map_creation.gen_beats as beat_generator
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 from tools.utils.huggingface import model_download
 from bs_shift.export_map import *
 

--- a/main_training.py
+++ b/main_training.py
@@ -4,7 +4,8 @@ import shutil
 import sys
 import subprocess
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 
 
 from training.helpers import test_gpu_tf

--- a/map_creation/artificial_mod.py
+++ b/map_creation/artificial_mod.py
@@ -1,7 +1,8 @@
 # helper functions for changing the map apart from the original input
 from random import random
 
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 
 
 def mirror_notes(n):

--- a/map_creation/class_helpers.py
+++ b/map_creation/class_helpers.py
@@ -2,7 +2,8 @@ import numpy as np
 from sklearn.preprocessing import OneHotEncoder
 import joblib
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 
 
 def update_out_class(in_class_l, y_class, idx):

--- a/map_creation/gen_beats.py
+++ b/map_creation/gen_beats.py
@@ -24,7 +24,8 @@ from training.tensorflow_models import *
 
 from lighting_prediction.generate_lighting import generate
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.utils import numpy_shorts
 from tools.config.mapper_selection import get_full_model_path
 

--- a/map_creation/gen_obstacles.py
+++ b/map_creation/gen_obstacles.py
@@ -1,7 +1,8 @@
 import numpy as np
 from random import randint
 
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 
 
 def add_obstacle(obstacles: list, position: int, first_time, last_time):

--- a/map_creation/gen_sliders.py
+++ b/map_creation/gen_sliders.py
@@ -1,7 +1,8 @@
 import numpy as np
 from random import randint, random
 
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 from map_creation.sanity_check import calc_note_speed
 
 

--- a/map_creation/map_creator.py
+++ b/map_creation/map_creator.py
@@ -10,7 +10,8 @@ from map_creation.sanity_check import sanity_check_notes, improve_timings
 from map_creation.gen_obstacles import calculate_obstacles
 from map_creation.gen_sliders import calculate_sliders
 from map_creation.artificial_mod import gimme_more_notes
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 
 
 def create_map(y_class_num, timings, events, name, bpm, pitch_input, pitch_times):

--- a/map_creation/map_creator_deprecated.py
+++ b/map_creation/map_creator_deprecated.py
@@ -10,7 +10,8 @@ from map_creation.sanity_check import sanity_check_notes, improve_timings
 from map_creation.gen_obstacles import calculate_obstacles
 # from map_creation.gen_sliders import calculate_sliders
 from map_creation.artificial_mod import gimme_more_notes
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 
 
 def create_map_depr(y_class_num, timings, events, name, bpm, pitch_input, pitch_times):

--- a/map_creation/note_postprocessing.py
+++ b/map_creation/note_postprocessing.py
@@ -1,4 +1,5 @@
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 import random
 
 

--- a/map_creation/sanity_check.py
+++ b/map_creation/sanity_check.py
@@ -9,7 +9,8 @@ import librosa
 # import matplotlib.pyplot as plt
 from scipy.signal import savgol_filter
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.utils.numpy_shorts import get_factor_from_max_speed, add_onset_half_times
 
 

--- a/preprocessing/beat_data_helper.py
+++ b/preprocessing/beat_data_helper.py
@@ -1,7 +1,8 @@
 import pickle
 import numpy as np
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 
 
 def load_raw_beat_data(name_ar):

--- a/preprocessing/bs_mapper_pre.py
+++ b/preprocessing/bs_mapper_pre.py
@@ -3,7 +3,8 @@ from sklearn.preprocessing import OneHotEncoder
 import pickle
 
 from preprocessing.beat_data_helper import *
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 from tools.utils.numpy_shorts import reduce_number_of_songs
 from training.helpers import filter_by_bps
 from preprocessing.music_processing import run_music_preprocessing

--- a/preprocessing/map_info_processing.py
+++ b/preprocessing/map_info_processing.py
@@ -1,7 +1,8 @@
 import os
 import json
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 
 
 def get_mapper_name(name_ar):

--- a/preprocessing/music_processing.py
+++ b/preprocessing/music_processing.py
@@ -5,7 +5,8 @@ import aubio
 import numpy as np
 
 from bs_shift.bps_find_songs import bps_find_songs
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 from tools.fail_list.black_list import append_fail, delete_fails
 from tools.utils import numpy_shorts
 from tools.utils.load_and_save import save_npy

--- a/tests/test_training_helpers.py
+++ b/tests/test_training_helpers.py
@@ -6,7 +6,8 @@ from keras.layers import Flatten
 
 from training import helpers as helpers_module
 from training import tensorflow_models as tf_models
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 
 
 def test_filter_by_bps_uses_bpm_selection(monkeypatch):

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -1,0 +1,8 @@
+"""Configuration package exposing shared configuration helpers."""
+
+from .config import Config, get_config
+
+# Expose a module-level reference for convenience
+config = get_config()
+
+__all__ = ["Config", "config", "get_config"]

--- a/tools/config/config.py
+++ b/tools/config/config.py
@@ -1,221 +1,228 @@
 import numpy as np
 
-# from map_creation.sanity_check import improve_timings
 
-########################################
-# config file for all important values 
-# used in multiple codes
-########################################
-InfernoSaber_version = "1.7.1.app8"  # coded into the info.dat file
-bs_mapping_version = "v3"  # allows to generate advanced features like arcs
-# bs_mapping_version = "v2"  # legacy mode, may be deprecated in future
+class Config:
+    """Container for InfernoSaber configuration values."""
 
-"""Do change"""
-# select mapper style
-# use_mapper_selection = "pp3_15"
-# use_mapper_selection = "easy_15"
-# use_mapper_selection = "hard_15"
-# use_mapper_selection = "expert_15"
-use_mapper_selection = "fav_15"
+    def __init__(self) -> None:
+        """Initialize configuration with default values."""
+        # General settings
+        self.InfernoSaber_version = "1.7.1.app8"  # coded into the info.dat file
+        self.bs_mapping_version = "v3"  # allows to generate advanced features like arcs
+        # self.bs_mapping_version = "v2"  # legacy mode, may be deprecated in future
 
-"""Change only for new training"""
-use_mapper_selection = use_mapper_selection.lower()
-use_bpm_selection = True   # use number of beats for selection of maps in training
-min_bps_limit = 2  # minimum beats_per_second value for training
-max_bps_limit = 12  # maximum beats_per_second value for training
+        # Mapper selection
+        # self.use_mapper_selection = "pp3_15"
+        # self.use_mapper_selection = "easy_15"
+        # self.use_mapper_selection = "hard_15"
+        # self.use_mapper_selection = "expert_15"
+        self.use_mapper_selection = "fav_15"
 
-"""Change for application"""
-# Map creation model configuration
-max_speed = 4 * 8.0  # set around 5-40 (normal-expert++)
-add_beat_intensity = 95  # try to match bps by x% [80, 120]
-gimme_more_notes_flag = True   # try to always use notes on both sides
-gimme_more_notes_prob = 0.25     # probability to activate [0.0-1.0]
-cdf = 1.2  # cut director factor (to calculate speed, [0.5, 1.5])
-cdf_lr = 1.15  # speed addition factor for left right movement
-expert_fact = 0.63  # expert plus to expert factor [0.6, 0.7]
-create_expert_flag = True  # create second expert map
-thresh_beat = 0.45  # minimum beat response required to trigger generator [0.3, 0.6]
-thresh_onbeat = 0.09
-# thresh_pitch = 0.90  # minimum beat for pitch check (0.8,low-1.5,high)
-threshold_start = 1.1  # factor for start and end threshold [0.8, 1.2]
-threshold_end = 0.7    # factor for start and end threshold (squared) [0.6, 1.1]
-factor_pitch_certainty = 0.5  # select emphasis on first (>1) or second pitch method
-factor_pitch_meanmax = 3    # select pitch certainty for mean (>=3) or max (<3)
-random_note_map_factor = 0.3  # stick note map to random song/center (set to 0 to disable)
-random_note_map_change = 3  # change frequency for center (1-5)
-# quick_start = 0     # map quick start mode (0 off, 1-3 on)    # TODO: rework
-t_diff_bomb = 1.5   # minimum time between notes to add bomb
-t_diff_bomb_react = 0.3  # minimum time between finished added bombs
-allow_mismatch_flag = False  # if True, wrong turned notes won't be removed
-flow_model_flag = True  # use improved direction flow
-# furious_lighting_flag = False  # increase frequency of light effects
-normalize_song_flag = True  # normalize song volume
-increase_volume_flag = True  # increase song volume (only used in combination with normalize flag)
-audio_rms_goal = 0.60
-allow_dot_notes = False  # if False, all notes must have a cut direction
-jump_speed_offset = -0.2
-map_filler_iters = 10  # max iterations for map filler
-add_dot_notes = 2  # add dot notes for fastest patterns in percent [0-10]
-add_breaks_flag = True  # add breaks after strong patterns
-silence_threshold = 0.20   # silence threshold quantile value [0.0, 0.3]
-silence_thresh_hard = 0.25  # add fixed threshold to dynamic value [0-2]
-add_silence_flag = True  # whether to apply silence threshold
-emphasize_beats_flag = True  # emphasize beats into double notes
-single_notes_only_flag = False  # no more double notes
-single_notes_only_strict_flag = True  # if previous flag applied, restricts to one note at a time
-single_notes_remove_lr = 0.4   # >0.5 removes left, <0.5 removes right more often
-add_obstacle_flag = True  # add obstacles in free areas
-obstacle_time_gap = [0.3, 0.8]  # time gap before [0.2-1] after [0.5-2]
-obstacle_min_duration = 0.1  # minimum duration for each obstacle [0.1-2]
-obstacle_max_count = 2  # maximum appearance count for obstacles
-sporty_obstacles = False
-add_slider_flag = True  # add arcs between notes in free areas
-slider_time_gap = [0.5, 12.0]    # time gap in seconds
-slider_probability = 0.8    # [0.1-1.0] with 1 meaning all on
-slider_movement_minimum = 3   # minimum movement between notes [0-5]
-slider_radius_multiplier = 1.0  # [0.5-2.0]
-slider_turbo_start = True   # start slider towards first note
-auto_move_song_afterwards = False  # Cut out song after generation and move to y_done folder
+        # Training configuration
+        self.use_mapper_selection = self.use_mapper_selection.lower()
+        self.use_bpm_selection = True   # use number of beats for selection of maps in training
+        self.min_bps_limit = 2  # minimum beats_per_second value for training
+        self.max_bps_limit = 12  # maximum beats_per_second value for training
 
-check_all_first_notes = True  # if False only change dot notes
-first_note_layer_threshold = 1  # Layer index from where first note should face up [0(all up)-3(all down)]
-allow_double_first_notes = False  # if False remove second note if necessary for first occurrence
-# improve timings
-# improve_timings_mcfactor = 2.5  # max change bandwidth (2 wide, 4+ narrow)
-# improve_timings_mcchange = 1.2   # max change time in seconds
-# improve_timings_act_time = 0.35  # min time gap to activate
+        # Map creation model configuration
+        self.max_speed = 4 * 8.0  # set around 5-40 (normal-expert++)
+        self.add_beat_intensity = 95  # try to match bps by x% [80, 120]
+        self.gimme_more_notes_flag = True   # try to always use notes on both sides
+        self.gimme_more_notes_prob = 0.25     # probability to activate [0.0-1.0]
+        self.cdf = 1.2  # cut director factor (to calculate speed, [0.5, 1.5])
+        self.cdf_lr = 1.15  # speed addition factor for left right movement
+        self.expert_fact = 0.63  # expert plus to expert factor [0.6, 0.7]
+        self.create_expert_flag = True  # create second expert map
+        self.thresh_beat = 0.45  # minimum beat response required to trigger generator [0.3, 0.6]
+        self.thresh_onbeat = 0.09
+        # self.thresh_pitch = 0.90  # minimum beat for pitch check (0.8,low-1.5,high)
+        self.threshold_start = 1.1  # factor for start and end threshold [0.8, 1.2]
+        self.threshold_end = 0.7    # factor for start and end threshold (squared) [0.6, 1.1]
+        self.factor_pitch_certainty = 0.5  # select emphasis on first (>1) or second pitch method
+        self.factor_pitch_meanmax = 3    # select pitch certainty for mean (>=3) or max (<3)
+        self.random_note_map_factor = 0.3  # stick note map to random song/center (set to 0 to disable)
+        self.random_note_map_change = 3  # change frequency for center (1-5)
+        # self.quick_start = 0     # map quick start mode (0 off, 1-3 on)    # TODO: rework
+        self.t_diff_bomb = 1.5   # minimum time between notes to add bomb
+        self.t_diff_bomb_react = 0.3  # minimum time between finished added bombs
+        self.allow_mismatch_flag = False  # if True, wrong turned notes won't be removed
+        self.flow_model_flag = True  # use improved direction flow
+        # self.furious_lighting_flag = False  # increase frequency of light effects
+        self.normalize_song_flag = True  # normalize song volume
+        self.increase_volume_flag = True  # increase song volume (only used in combination with normalize flag)
+        self.audio_rms_goal = 0.60
+        self.allow_dot_notes = False  # if False, all notes must have a cut direction
+        self.jump_speed_offset = -0.2
+        self.map_filler_iters = 10  # max iterations for map filler
+        self.add_dot_notes = 2  # add dot notes for fastest patterns in percent [0-10]
+        self.add_breaks_flag = True  # add breaks after strong patterns
+        self.silence_threshold = 0.20   # silence threshold quantile value [0.0, 0.3]
+        self.silence_thresh_hard = 0.25  # add fixed threshold to dynamic value [0-2]
+        self.add_silence_flag = True  # whether to apply silence threshold
+        self.emphasize_beats_flag = True  # emphasize beats into double notes
+        self.single_notes_only_flag = False  # no more double notes
+        self.single_notes_only_strict_flag = True  # if previous flag applied, restricts to one note at a time
+        self.single_notes_remove_lr = 0.4   # >0.5 removes left, <0.5 removes right more often
+        self.add_obstacle_flag = True  # add obstacles in free areas
+        self.obstacle_time_gap = np.asarray([0.3, 0.8])  # time gap before [0.2-1] after [0.5-2]
+        self.obstacle_min_duration = 0.1  # minimum duration for each obstacle [0.1-2]
+        self.obstacle_max_count = 2  # maximum appearance count for obstacles
+        self.sporty_obstacles = False
+        self.add_slider_flag = True  # add arcs between notes in free areas
+        self.slider_time_gap = [0.5, 12.0]    # time gap in seconds
+        self.slider_probability = 0.8    # [0.1-1.0] with 1 meaning all on
+        self.slider_movement_minimum = 3   # minimum movement between notes [0-5]
+        self.slider_radius_multiplier = 1.0  # [0.5-2.0]
+        self.slider_turbo_start = True   # start slider towards first note
+        self.auto_move_song_afterwards = False  # Cut out song after generation and move to y_done folder
 
-add_waveform_pattern_flag = 0   # [0: off, 1: on, 2: double on]
-waveform_pattern = [
-    [0, 1, 2, 3, 2, 1],
-    [0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 1, 1],
-    [0, 1, 2, 1, 2, 3, 2, 1, 2, 1, 0],
-    [0, 1, 2, 1],
-    [1, 2, 3, 2],
-    [0, 2, 1, 3, 1, 2],
-    # [0, 1],
-    # [2, 3],
-    # [0, 3, 0, 1, 2, 3, 2, 1, 0, 3],
-]
-waveform_apply_dir = [0, 4, 5, 1, 6, 7]     # either [0, 1] or [0, 4, 5, 1, 6, 7]
-waveform_pattern_length = 25   # pattern length in sampling rate [10-200]
-waveform_threshold = 4  # minimum number of notes applicable for waveform to start
+        self.check_all_first_notes = True  # if False only change dot notes
+        self.first_note_layer_threshold = 1  # Layer index from where first note should face up [0(all up)-3(all down)]
+        self.allow_double_first_notes = False  # if False remove second note if necessary for first occurrence
+        # improve timings
+        # self.improve_timings_mcfactor = 2.5  # max change bandwidth (2 wide, 4+ narrow)
+        # self.improve_timings_mcchange = 1.2   # max change time in seconds
+        # self.improve_timings_act_time = 0.35  # min time gap to activate
 
-"""Pinokio app only"""
-num_workers = 4
-silence_threshold_percentage = 100
-difficulty_1 = 4
-difficulty_2 = 5
-difficulty_3 = 6
-difficulty_4 = 7
-difficulty_5 = 8
+        self.add_waveform_pattern_flag = 0   # [0: off, 1: on, 2: double on]
+        self.waveform_pattern = [
+            [0, 1, 2, 3, 2, 1],
+            [0, 0, 1, 1, 2, 2, 3, 3, 2, 2, 1, 1],
+            [0, 1, 2, 1, 2, 3, 2, 1, 2, 1, 0],
+            [0, 1, 2, 1],
+            [1, 2, 3, 2],
+            [0, 2, 1, 3, 1, 2],
+            # [0, 1],
+            # [2, 3],
+            # [0, 3, 0, 1, 2, 3, 2, 1, 0, 3],
+        ]
+        self.waveform_apply_dir = [0, 4, 5, 1, 6, 7]     # either [0, 1] or [0, 4, 5, 1, 6, 7]
+        self.waveform_pattern_length = 25   # pattern length in sampling rate [10-200]
+        self.waveform_threshold = 4  # minimum number of notes applicable for waveform to start
 
-"""Caution on changes"""
-verbose_level = 1       # verbose level from 0 (only ETA) to 5 (all messages)
-obstacle_crouch_width = 4
-obstacle_width = 1
-max_obstacle_height = 5     # <= 5
-# normal obstacles
-norm_obstacle_allowed_types = [0, 1, 2]  # 0wall, 1ceiling, 2jump, 3onesaber
-norm_obstacle_positions = [[0], [3]]  # outside position of notes
-# sporty obstacles
-sport_obstacle_allowed_types = [0, 1]  # (ceiling walls for crouch are fixed)
-sport_obstacle_positions = [[0, 1, 1], [2, 2, 3]]  # inside position of notes
+        # Pinokio app settings
+        self.num_workers = 4
+        self.silence_threshold_percentage = 100
+        self.difficulty_1 = 4
+        self.difficulty_2 = 5
+        self.difficulty_3 = 6
+        self.difficulty_4 = 7
+        self.difficulty_5 = 8
 
-check_silence_flag = True  # check for extremely silent songs
-check_silence_value = -12.6  # value in dB [-15 (low filter), -11 (high filter)]
-jump_speed_expert_factor = 0.91     # factor from expert+ to expert
-jsb_offset = [0.21, 0.15]  # note jump speed offset for Expert, Expert+ (range [-0.5, 0.5])
-jsb_offset_min = [-0.2, -0.4]  # minimum allowed values (expert, expert+)
-jsb_offset_factor = 0.011  # note jump factor for high difficulties
-use_fixed_bpm = 0   # use fixed bpm or set to None for the song bpm
-max_njs = 26  # maximum Note Jump Speed allowed
-decr_speed_range = 30  # range for start and end (n first and last notes)
-decr_speed_val = 0.35  # decrease max speed at start
-reaction_time = 1.15   # reaction time (0.5-2)
-reaction_time_fact = 0.013  # factor including max_speed
-jump_speed = 12.4  # jump speed from beat saber (10-15)
-jump_speed_fact = 0.310  # factor including max_speed
-min_beat_time = 1 / 16  # in seconds (first sanity check)
-beat_spacing = 5587 / 196  # 5587/196s = 28.5051 steps/s
-# favor_last_class = 0.15     # set factor to favor the next beat class (0.0-0.3)
-max_double_note_speed = 25  # set maximum speed difference between double notes (10-30)
-emphasize_beats_3 = 0.010  # fraction beats to triple
-emphasize_beats_3_fact = 0.001  # factor incl max_speed
-emphasize_beats_2 = 0.40  # fraction beats to double
-emphasize_beats_2_fact = 0.002  # factor incl max_speed
-emphasize_beats_quantile = 0.65     # disengage quantile of fast patterns
-shift_beats_fact = 0.30  # fraction beats to shift in cut direction
-# add_beat_fact = 0.90        # fraction add beats (beat_generator)
-add_beat_max_bounds = [0.1, 0.5, 0.8, 1.6]
-# pitches_allowed = [40, 50]  # percentage of pitches to be over threshold
-add_start_end_beats = True
+        # Advanced configuration
+        self.verbose_level = 1       # verbose level from 0 (only ETA) to 5 (all messages)
+        self.obstacle_crouch_width = 4
+        self.obstacle_width = 1
+        self.max_obstacle_height = 5     # <= 5
+        # normal obstacles
+        self.norm_obstacle_allowed_types = [0, 1, 2]  # 0wall, 1ceiling, 2jump, 3onesaber
+        self.norm_obstacle_positions = [[0], [3]]  # outside position of notes
+        # sporty obstacles
+        self.sport_obstacle_allowed_types = [0, 1]  # (ceiling walls for crouch are fixed)
+        self.sport_obstacle_positions = [[0, 1, 1], [2, 2, 3]]  # inside position of notes
+
+        self.check_silence_flag = True  # check for extremely silent songs
+        self.check_silence_value = -12.6  # value in dB [-15 (low filter), -11 (high filter)]
+        self.jump_speed_expert_factor = 0.91     # factor from expert+ to expert
+        self.jsb_offset = [0.21, 0.15]  # note jump speed offset for Expert, Expert+ (range [-0.5, 0.5])
+        self.jsb_offset_min = [-0.2, -0.4]  # minimum allowed values (expert, expert+)
+        self.jsb_offset_factor = 0.011  # note jump factor for high difficulties
+        self.use_fixed_bpm = 0   # use fixed bpm or set to None for the song bpm
+        self.max_njs = 26  # maximum Note Jump Speed allowed
+        self.decr_speed_range = 30  # range for start and end (n first and last notes)
+        self.decr_speed_val = 0.35  # decrease max speed at start
+        self.reaction_time = 1.15   # reaction time (0.5-2)
+        self.reaction_time_fact = 0.013  # factor including max_speed
+        self.jump_speed = 12.4  # jump speed from beat saber (10-15)
+        self.jump_speed_fact = 0.310  # factor including max_speed
+        self.min_beat_time = 1 / 16  # in seconds (first sanity check)
+        self.beat_spacing = 5587 / 196  # 5587/196s = 28.5051 steps/s
+        # self.favor_last_class = 0.15     # set factor to favor the next beat class (0.0-0.3)
+        self.max_double_note_speed = 25  # set maximum speed difference between double notes (10-30)
+        self.emphasize_beats_3 = 0.010  # fraction beats to triple
+        self.emphasize_beats_3_fact = 0.001  # factor incl max_speed
+        self.emphasize_beats_2 = 0.40  # fraction beats to double
+        self.emphasize_beats_2_fact = 0.002  # factor incl max_speed
+        self.emphasize_beats_quantile = 0.65     # disengage quantile of fast patterns
+        self.shift_beats_fact = 0.30  # fraction beats to shift in cut direction
+        # self.add_beat_fact = 0.90        # fraction add beats (beat_generator)
+        self.add_beat_max_bounds = [0.1, 0.5, 0.8, 1.6]
+        # self.pitches_allowed = [40, 50]  # percentage of pitches to be over threshold
+        self.add_start_end_beats = True
+
+        # Data processing configuration
+        self.training_songs_diff = 'ExpertPlus'
+        self.allow_training_diff2 = True
+        self.training_songs_diff2 = 'Expert'  # second try if first one is not available
+
+        self.general_diff = 'ExpertPlus'
+        self.exclude_requirements = False    # exclude all maps which have any kind of requirement noted
+        self.random_seed = 3
+        self.min_time_diff = 0.01  # minimum time between cuts, otherwise synchronized
+        self.samplerate_music = 14800  # samplerate for the music import
+        self.hop_size = 512
+        self.window = 2.0  # window in seconds for each song to spectrum picture (from wav_to_pic)
+        self.specgram_res = 24  # y resolution of the spectrogram (frequency subdivisions)
+        # self.ram_limit = 24      # free RAM in GB (unused currently)
+        self.vram_limit = 20     # free VRAM in GB (needed for lighting training)
+
+        # Model versions
+        self.enc_version = 'tf_model_enc_'
+        self.autoenc_version = 'tf_model_autoenc_'
+        self.mapper_version = 'tf_model_mapper_'
+        self.beat_gen_version = 'tf_beat_gen_'
+        self.event_gen_version = 'tf_event_gen_'
+
+        # Autoencoder model configuration
+        self.learning_rate = 3e-4  # model learning rate
+        self.n_epochs = 50  # number of total epochs
+        self.batch_size = 128  # batch size
+        self.test_samples = 10  # number of test files to plot (excluded from training)
+        self.bottleneck_len = 16  # size of bottleneck distribution (1D array)
+        self.autoenc_song_limit = 120    # maximum number of songs used for training, to not overload RAM
+
+        # Mapper model configuration
+        self.map_learning_rate = 4e-4  # model learning rate
+        self.map_n_epochs = 180  # number of total epochs
+        self.map_batch_size = 128  # batch size
+        self.map_test_samples = 10  # number of test files to plot (excluded from training)
+        self.lstm_len = 16
+        self.remove_double_notes = False
+        self.mapper_song_limit = 240    # maximum number of songs used for training, to not overload RAM
+
+        # Beat prediction model configuration
+        self.beat_learning_rate = 5e-4
+        self.beat_n_epochs = 80
+        self.beat_batch_size = 128
+        self.tcn_len = 24
+        self.tcn_test_samples = 350
+        self.delete_offbeats = 0.6  # < 1 delete non-beats to free ram
+        # self.tcn_skip = 10
+        self.beat_song_limit = 240    # maximum number of songs used for training, to not overload RAM
+
+        # Event prediction model configuration
+        self.event_learning_rate = 1e-3
+        self.event_n_epochs = 180
+        self.event_lstm_len = 16
+        self.event_batch_size = 128
+        # event_song_limit covered by vram_limit
+
+        # Needed for reset
+        self.max_speed_orig = self.max_speed
+        self.add_beat_intensity_orig = self.add_beat_intensity
+        self.silence_threshold_orig = self.silence_threshold
+        self.jump_speed_offset_orig = self.jump_speed_offset
+        self.obstacle_time_gap_orig = self.obstacle_time_gap
+        self.thresh_beat_orig = self.thresh_beat
+        self.thresh_onbeat_orig = self.thresh_onbeat
 
 
-"""Do not change unless you change the DNN models"""
-# Data Processing configuration
-training_songs_diff = 'ExpertPlus'
-allow_training_diff2 = True
-training_songs_diff2 = 'Expert'  # second try if first one is not available
+_CONFIG_INSTANCE = Config()
 
-general_diff = 'ExpertPlus'
-exclude_requirements = False    # exclude all maps which have any kind of requirement noted
-random_seed = 3
-min_time_diff = 0.01  # minimum time between cuts, otherwise synchronized
-samplerate_music = 14800  # samplerate for the music import
-hop_size = 512
-window = 2.0  # window in seconds for each song to spectrum picture (from wav_to_pic)
-specgram_res = 24  # y resolution of the spectrogram (frequency subdivisions)
-# ram_limit = 24      # free RAM in GB (unused currently)
-vram_limit = 20     # free VRAM in GB (needed for lighting training)
 
-# Model versions
-enc_version = 'tf_model_enc_'
-autoenc_version = 'tf_model_autoenc_'
-mapper_version = 'tf_model_mapper_'
-beat_gen_version = 'tf_beat_gen_'
-event_gen_version = 'tf_event_gen_'
+def get_config() -> Config:
+    """Return the shared configuration instance."""
+    return _CONFIG_INSTANCE
 
-# Autoencoder model configuration
-learning_rate = 3e-4  # model learning rate
-n_epochs = 50  # number of total epochs
-batch_size = 128  # batch size
-test_samples = 10  # number of test files to plot (excluded from training)
-bottleneck_len = 16  # size of bottleneck distribution (1D array)
-autoenc_song_limit = 120    # maximum number of songs used for training, to not overload RAM
 
-# Mapper model configuration
-map_learning_rate = 4e-4  # model learning rate
-map_n_epochs = 180  # number of total epochs
-map_batch_size = 128  # batch size
-map_test_samples = 10  # number of test files to plot (excluded from training)
-lstm_len = 16
-remove_double_notes = False
-mapper_song_limit = 240    # maximum number of songs used for training, to not overload RAM
-
-# Beat prediction model configuration
-beat_learning_rate = 5e-4
-beat_n_epochs = 80
-beat_batch_size = 128
-tcn_len = 24
-tcn_test_samples = 350
-delete_offbeats = 0.6  # < 1 delete non-beats to free ram
-# tcn_skip = 10
-beat_song_limit = 240    # maximum number of songs used for training, to not overload RAM
-
-# Event prediction model configuration
-event_learning_rate = 1e-3
-event_n_epochs = 180
-event_lstm_len = 16
-event_batch_size = 128
-# event_song_limit covered by vram_limit
-
-# needed for reset
-max_speed_orig = max_speed
-add_beat_intensity_orig = add_beat_intensity
-silence_threshold_orig = silence_threshold
-jump_speed_offset_orig = jump_speed_offset
-obstacle_time_gap = np.asarray(obstacle_time_gap)
-obstacle_time_gap_orig = obstacle_time_gap
-thresh_beat_orig = thresh_beat
-thresh_onbeat_orig = thresh_onbeat
+__all__ = ["Config", "get_config"]

--- a/tools/config/mapper_selection.py
+++ b/tools/config/mapper_selection.py
@@ -1,6 +1,7 @@
 import os
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 
 
 def return_mapper_list(mapper_shortcut):

--- a/tools/config/paths.py
+++ b/tools/config/paths.py
@@ -9,7 +9,8 @@
 # /mnt/c/Users/frede/Desktop/BS_Automapper/InfernoSaber---BeatSaber-Automapper
 
 import os
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 
 
 ################################# (change this for your pc)

--- a/tools/utils/break_test.py
+++ b/tools/utils/break_test.py
@@ -1,7 +1,8 @@
 # import matplotlib.pyplot as plt
 # from scipy.signal import savgol_filter
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from map_creation.sanity_check import add_breaks
 from tools.utils.load_and_save import load_pkl
 

--- a/tools/utils/huggingface.py
+++ b/tools/utils/huggingface.py
@@ -1,7 +1,8 @@
 import os
 from huggingface_hub import snapshot_download
 
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.config.mapper_selection import get_full_model_path
 
 

--- a/training/eval_autoenc_music.py
+++ b/training/eval_autoenc_music.py
@@ -2,7 +2,8 @@ from helpers import *
 from plot_model import run_plot_autoenc
 from tensorflow_models import *
 from preprocessing.music_processing import run_music_preprocessing
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.config.mapper_selection import get_full_model_path
 
 # Setup configuration

--- a/training/eval_bs_automapper.py
+++ b/training/eval_bs_automapper.py
@@ -8,7 +8,8 @@ from helpers import *
 from lighting_prediction.train_lighting import lstm_shift_events_half
 from tensorflow_models import *
 from preprocessing.bs_mapper_pre import load_ml_data, lstm_shift
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.config.mapper_selection import get_full_model_path
 
 # Check Cuda compatible GPU

--- a/training/helpers.py
+++ b/training/helpers.py
@@ -11,7 +11,8 @@ parent_dir = os.path.abspath(os.path.join(script_dir, ".."))
 sys.path.append(parent_dir)
 
 from tools.utils.load_and_save import load_npy
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 from tools.config.mapper_selection import return_mapper_list, get_full_model_path
 from preprocessing.map_info_processing import get_maps_from_mapper
 

--- a/training/plot_model.py
+++ b/training/plot_model.py
@@ -1,7 +1,8 @@
 # import matplotlib.pyplot as plt
 import numpy as np
 
-from tools.config import paths, config
+from tools.config import paths, get_config
+config = get_config()
 
 
 def plot_autoenc_results(img_in, img_repr, img_out, n_samples, scale_repr=True, save=False):

--- a/training/tensorflow_models.py
+++ b/training/tensorflow_models.py
@@ -5,7 +5,8 @@ from tcn import TCN  # pip install keras-tcn
 from keras.models import Model
 import numpy as np
 
-from tools.config import config
+from tools.config import get_config
+config = get_config()
 
 
 def create_keras_model(model_type, dim_in=[], dim_out=None):

--- a/training/train_autoenc_music.py
+++ b/training/train_autoenc_music.py
@@ -19,7 +19,8 @@ from helpers import test_gpu_tf, filter_by_bps, load_keras_model
 from plot_model import run_plot_autoenc
 from tensorflow_models import create_keras_model
 from preprocessing.music_processing import run_music_preprocessing
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from tools.fail_list.black_list import delete_fails
 from tools.utils.numpy_shorts import reduce_number_of_songs
 

--- a/training/train_bs_automapper.py
+++ b/training/train_bs_automapper.py
@@ -8,7 +8,8 @@ from tabulate import tabulate
 from helpers import test_gpu_tf, ai_encode_song, load_keras_model, categorical_to_class
 from tensorflow_models import create_keras_model
 from preprocessing.bs_mapper_pre import load_ml_data, lstm_shift
-from tools.config import config, paths
+from tools.config import get_config, paths
+config = get_config()
 from lighting_prediction.train_lighting import lstm_shift_events_half
 
 


### PR DESCRIPTION
## Summary
- convert the configuration module into a `Config` class and expose a shared instance
- export the shared config object from the package for compatibility
- update all modules that used the old module-level config to acquire the shared instance via `get_config()`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4250cf2848327987a9b867c93f2a3