### PR TITLE
Prompt for repo creation when selecting input path and streamline ETA output

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -3,7 +3,7 @@ import ffmpy
 import requests  # to check for updates opn GitHub
 
 import gradio as gr
-from tkinter import Tk, filedialog
+from tkinter import Tk, filedialog, messagebox
 import os
 import shutil
 
@@ -24,6 +24,9 @@ from tools.utils.huggingface import model_download
 data_folder_name = 'Data'
 bs_folder_name = "Beat Saber_Data/CustomLevels"
 bs_folder_name2 = "SharedMaps/CustomLevels"
+
+REQUIRED_REPO_FOLDERS = ("model", "prediction", "training")
+FOLDER_SETUP_CANCELED_MESSAGE = "Folder setup canceled"
 
 update_check_response = None
 
@@ -103,35 +106,72 @@ update_status = check_for_updates()
 #             return str(filename)
 
 
+def _ensure_repo_setup(folder_path, previous_folder, root):
+    missing_folders = [
+        folder for folder in REQUIRED_REPO_FOLDERS
+        if not os.path.isdir(os.path.join(folder_path, folder))
+    ]
+
+    if not missing_folders:
+        set_app_paths(folder_path)
+        return paths.dir_path, 'Finished folder setup'
+
+    prompt_message = (
+        "The selected folder is missing the InfernoSaber repository structure.\n"
+        f"Missing folders: {', '.join(missing_folders)}.\n"
+        "Do you want to create a new repository here?"
+    )
+    if messagebox.askyesno(
+        "InfernoSaber Setup",
+        prompt_message,
+        parent=root,
+    ):
+        set_app_paths(folder_path)
+        return paths.dir_path, 'Created new InfernoSaber repository'
+
+    return previous_folder, FOLDER_SETUP_CANCELED_MESSAGE
+
+
 def on_browse_input_path():
     root = Tk()
     root.attributes("-topmost", True)
     root.withdraw()
 
-    filename = filedialog.askdirectory()
-    filename = filename.replace('\\\\', '/').replace('\\', '/')
-    if filename:
-        if os.path.isdir(filename):
-            if len(os.listdir(filename)) > 5:
-                return str(filename), 'Error: Please select an empty folder to set up InfernoSaber'
-            if not os.path.basename(filename) == data_folder_name:
-                # filename = os.path.join(filename, data_folder_name)
-                filename += f"/{data_folder_name}"
-                if not os.path.isdir(filename):
-                    os.mkdir(filename)
-            if not filename.endswith('/'):
-                filename += '/'
+    previous_dir_path = paths.dir_path
+    created_data_dir = False
+
+    try:
+        filename = filedialog.askdirectory()
+        filename = filename.replace('\\\\', '/').replace('\\', '/')
+        if not filename:
+            return "Folder not selected", 'not set'
+        if not os.path.isdir(filename):
+            return "Folder not available", 'not set'
+        if len(os.listdir(filename)) > 5:
+            return str(filename), 'Error: Please select an empty folder to set up InfernoSaber'
+        if not os.path.basename(filename) == data_folder_name:
+            filename += f"/{data_folder_name}"
+            if not os.path.isdir(filename):
+                os.mkdir(filename)
+                created_data_dir = True
+        if not filename.endswith('/'):
+            filename += '/'
+
+        final_path, status_message = _ensure_repo_setup(filename, previous_dir_path, root)
+
+        if status_message == FOLDER_SETUP_CANCELED_MESSAGE and created_data_dir:
+            try:
+                if os.path.isdir(filename) and not os.listdir(filename):
+                    os.rmdir(filename)
+            except OSError:
+                pass
+
+        return str(final_path), status_message
+    finally:
+        try:
             root.destroy()
-            set_app_paths(filename)
-            return str(filename), 'Finished folder setup'
-        else:
-            filename = "Folder not available"
-            root.destroy()
-            return str(filename), 'not set'
-    else:
-        filename = "Folder not selected"
-        root.destroy()
-        return str(filename), 'not set'
+        except Exception:
+            pass
 
 
 def on_browse_bs_path():
@@ -318,7 +358,16 @@ def run_process(num_workers, use_model, diff1, diff2, diff3, diff4, diff5):
     while thread.is_alive() or not log_queue.empty():
         while not log_queue.empty():
             log_message = log_queue.get()
-            progress_log.append(log_message)
+            if log_message.startswith("### ETA:"):
+                # Replace the most recent ETA entry to avoid flooding the log
+                for index in range(len(progress_log) - 1, -1, -1):
+                    if progress_log[index].startswith("### ETA:"):
+                        progress_log[index] = log_message
+                        break
+                else:
+                    progress_log.append(log_message)
+            else:
+                progress_log.append(log_message)
             yield "\n".join(progress_log)
         time.sleep(0.2)  # Prevent busy-waiting
 

--- a/tests/test_config_implementation.py
+++ b/tests/test_config_implementation.py
@@ -1,0 +1,116 @@
+"""Tests validating consistent usage of the shared configuration object."""
+
+from __future__ import annotations
+
+import ast
+from importlib import reload
+from pathlib import Path
+
+import pytest
+
+from tools.config import config as shared_config
+from tools.config import get_config
+import tools.config.paths as paths_module
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _iter_config_scripts():
+    """Yield Python files that access the shared config instance."""
+    for path in REPO_ROOT.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        try:
+            source = path.read_text()
+        except UnicodeDecodeError:
+            # Non-text python file – skip safely.
+            continue
+        if "config = get_config(" in source:
+            yield path, source
+
+
+CONFIG_SCRIPTS = list(_iter_config_scripts())
+CONFIG_SCRIPT_IDS = [str(path) for path, _ in CONFIG_SCRIPTS]
+
+
+@pytest.mark.parametrize(
+    "script_path, source",
+    CONFIG_SCRIPTS,
+    ids=CONFIG_SCRIPT_IDS,
+)
+def test_scripts_import_and_assign_shared_config(script_path: Path, source: str) -> None:
+    """Every script should import and assign the shared config singleton."""
+    tree = ast.parse(source, filename=str(script_path))
+
+    imported_get_config = False
+    assigned_shared_config = False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if any(alias.name == "get_config" for alias in node.names):
+                imported_get_config = True
+        elif isinstance(node, ast.Assign):
+            targets_config = any(
+                isinstance(target, ast.Name) and target.id == "config" for target in node.targets
+            )
+            if not targets_config:
+                continue
+            value = node.value
+            if isinstance(value, ast.Call):
+                func = value.func
+                if isinstance(func, ast.Name) and func.id == "get_config":
+                    assigned_shared_config = True
+                elif isinstance(func, ast.Attribute) and func.attr == "get_config":
+                    assigned_shared_config = True
+
+    assert imported_get_config, f"{script_path} must import get_config from the config package"
+    assert assigned_shared_config, f"{script_path} must assign config = get_config()"
+
+
+def test_get_config_returns_singleton() -> None:
+    """The accessor must always return the same configuration instance."""
+    first = get_config()
+    second = get_config()
+
+    assert first is second
+
+
+def test_only_config_module_instantiates_config_class() -> None:
+    """Ensure the Config class is instantiated only inside its defining module."""
+    config_instantiations = []
+
+    for path in REPO_ROOT.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        source = path.read_text()
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "Config":
+                    config_instantiations.append(path)
+                elif isinstance(func, ast.Attribute) and func.attr == "Config":
+                    config_instantiations.append(path)
+
+    assert config_instantiations == [REPO_ROOT / "tools" / "config" / "config.py"]
+
+
+def test_paths_module_uses_current_mapper_selection(monkeypatch):
+    """Reloading the paths module should respect the active mapper selection."""
+    config = get_config()
+    original_selection = config.use_mapper_selection
+
+    try:
+        monkeypatch.setattr(config, "use_mapper_selection", "CustomMapper", raising=False)
+        reloaded_paths = reload(paths_module)
+        assert reloaded_paths.model_path.endswith("custommapper/"), reloaded_paths.model_path
+
+        monkeypatch.setattr(config, "use_mapper_selection", "", raising=False)
+        reloaded_paths = reload(paths_module)
+        assert reloaded_paths.model_path.endswith("general_new/"), reloaded_paths.model_path
+    finally:
+        monkeypatch.setattr(config, "use_mapper_selection", original_selection, raising=False)
+        reload(paths_module)
+
+    assert shared_config is get_config()


### PR DESCRIPTION
## Summary
- add a repository setup guard when selecting the InfernoSaber input folder so required directories are validated
- prompt users to confirm creating a new repository when the model, prediction, and training folders are missing
- clean up temporary Data directories if the user cancels the setup
- collapse repeated ETA logs into a single updating progress line during inference

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5961a4d1c8327aae98bf2fa6d0694