### PR TITLE
Add beat intensity training pipeline

### DIFF
--- a/preprocessing/intensity_pre.py
+++ b/preprocessing/intensity_pre.py
@@ -1,0 +1,126 @@
+"""Data preparation helpers for beat intensity model training."""
+
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+from preprocessing.beat_data_helper import load_raw_beat_data, sort_beats_by_time
+from preprocessing.music_processing import run_music_preprocessing
+from tools.config import get_config
+from tools.utils.numpy_shorts import reduce_number_of_songs
+from training.helpers import filter_by_bps
+
+config = get_config()
+
+
+def _remove_indices(values: Sequence[float], indices: Sequence[int]) -> np.ndarray:
+    """Return a copy of *values* with the provided *indices* removed."""
+    if not indices:
+        return np.asarray(values, dtype=np.float32)
+    mask = np.ones(len(values), dtype=bool)
+    mask[np.asarray(indices, dtype=int)] = False
+    return np.asarray(values, dtype=np.float32)[mask]
+
+
+def _compute_song_average_bps(note_times: np.ndarray) -> float:
+    """Compute the average beats-per-second of a song."""
+    if note_times.size <= 1:
+        return 0.0
+    duration = float(note_times[-1] - note_times[0])
+    if duration <= 0:
+        return 0.0
+    return float(note_times.size / duration)
+
+
+def _compute_window_intensity(note_times: np.ndarray, window_seconds: float) -> np.ndarray:
+    """Compute local beat intensity ratios for each note time.
+
+    The returned array contains, for every note time, the ratio between the
+    average beats-per-second inside a symmetrical ``window_seconds`` segment
+    around the note and the global song average beats-per-second.
+    """
+    if note_times.size == 0:
+        return np.zeros((0, 1), dtype=np.float32)
+
+    avg_bps = _compute_song_average_bps(note_times)
+    if avg_bps <= 0:
+        return np.zeros((note_times.size, 1), dtype=np.float32)
+
+    half_window = window_seconds / 2.0
+    intensities: List[float] = []
+
+    for time_point in note_times:
+        start = time_point - half_window
+        end = time_point + half_window
+        # Count beats within the window using vectorised comparisons.
+        beats_in_window = np.count_nonzero((note_times >= start) & (note_times < end))
+        window_bps = beats_in_window / window_seconds
+        intensities.append(window_bps / avg_bps)
+
+    return np.asarray(intensities, dtype=np.float32).reshape(-1, 1)
+
+
+def load_intensity_dataset() -> Tuple[np.ndarray, np.ndarray]:
+    """Load spectrogram windows and their beat intensity ratios.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        ``(song_windows, intensity_targets)`` where ``song_windows`` has shape
+        ``(n_samples, height, width, channels)`` and ``intensity_targets`` has
+        shape ``(n_samples, 1)``.
+    """
+    # Select maps according to the configured BPM limits.
+    name_ar, _ = filter_by_bps(config.min_bps_limit, config.max_bps_limit)
+    name_ar = reduce_number_of_songs(name_ar, hard_limit=config.intensity_song_limit)
+
+    # Load beat timing information for each song.
+    map_dict_notes, _, _ = load_raw_beat_data(name_ar)
+    _, time_ar = sort_beats_by_time(map_dict_notes)
+
+    # Prepare spectrogram inputs aligned with each beat time.
+    song_ar, rm_index_ar = run_music_preprocessing(
+        name_ar,
+        time_ar,
+        save_file=False,
+        song_combined=False,
+        channels_last=True,
+    )
+
+    windows_list: List[np.ndarray] = []
+    intensity_list: List[np.ndarray] = []
+
+    for song_windows, note_times, rm_idx in zip(song_ar, time_ar, rm_index_ar):
+        if len(song_windows) == 0 or len(note_times) == 0:
+            continue
+
+        cleaned_times = _remove_indices(note_times, rm_idx)
+        if cleaned_times.size == 0:
+            continue
+
+        # Align windows with cleaned note times.
+        if len(song_windows) != cleaned_times.size:
+            # Skip inconsistent samples to avoid shape mismatches.
+            continue
+
+        intensities = _compute_window_intensity(cleaned_times, config.window)
+        if intensities.size == 0:
+            continue
+
+        windows_list.append(song_windows.astype(np.float32))
+        intensity_list.append(intensities)
+
+    if not windows_list:
+        raise RuntimeError(
+            "No valid training samples were generated for the intensity dataset."
+        )
+
+    song_windows = np.concatenate(windows_list, axis=0).astype(np.float32)
+    intensity_targets = np.concatenate(intensity_list, axis=0).astype(np.float32)
+
+    return song_windows, intensity_targets
+
+
+__all__ = ["load_intensity_dataset"]

--- a/tools/config/config.py
+++ b/tools/config/config.py
@@ -200,6 +200,13 @@ class Config:
         # self.tcn_skip = 10
         self.beat_song_limit = 240    # maximum number of songs used for training, to not overload RAM
 
+        # Beat intensity model configuration
+        self.intensity_learning_rate = 3e-4
+        self.intensity_n_epochs = 80
+        self.intensity_batch_size = 128
+        self.intensity_test_samples = 350
+        self.intensity_song_limit = 240
+
         # Event prediction model configuration
         self.event_learning_rate = 1e-3
         self.event_n_epochs = 180

--- a/training/tensorflow_models.py
+++ b/training/tensorflow_models.py
@@ -58,6 +58,26 @@ def create_keras_model(model_type, dim_in=[], dim_out=None):
         model = Model(inputs=[input_a, input_b, input_c], outputs=out)
         return model
 
+    elif model_type == 'intensity_cnn':
+        input_img = Input(shape=dim_in[0], name='input_intensity_window')
+
+        x = Conv2D(32, (3, 3), activation='relu', padding='same')(input_img)
+        x = BatchNormalization()(x)
+        x = MaxPooling2D((2, 2), padding='same')(x)
+
+        x = Conv2D(64, (3, 3), activation='relu', padding='same')(x)
+        x = BatchNormalization()(x)
+        x = MaxPooling2D((2, 2), padding='same')(x)
+
+        x = Flatten('channels_last')(x)
+        x = Dense(128, activation='relu')(x)
+        x = Dropout(0.1)(x)
+
+        out = Dense(1, activation='linear', name='output_intensity')(x)
+
+        model = Model(inputs=input_img, outputs=out)
+        return model
+
     # autoencoder
     elif model_type == 'enc1':
         input_img = Input(shape=(24, 20, 1))

--- a/training/train_intensity.py
+++ b/training/train_intensity.py
@@ -1,0 +1,90 @@
+"""Training script for the beat intensity prediction model."""
+
+from datetime import datetime
+
+import numpy as np
+from keras.optimizers import Adam
+
+from helpers import load_keras_model
+from preprocessing.intensity_pre import load_intensity_dataset
+from tensorflow_models import create_keras_model
+from tools.config import get_config, paths
+
+config = get_config()
+
+# Configuration
+learning_rate = config.intensity_learning_rate
+n_epochs = config.intensity_n_epochs
+batch_size = config.intensity_batch_size
+test_samples_cfg = config.intensity_test_samples
+np.random.seed(config.random_seed)
+
+# Load dataset
+song_windows, intensity_targets = load_intensity_dataset()
+
+# Shuffle samples in unison
+permutation = np.random.permutation(song_windows.shape[0])
+song_windows = song_windows[permutation]
+intensity_targets = intensity_targets[permutation]
+
+# Split into train/validation/test sets
+test_samples = min(test_samples_cfg, max(1, song_windows.shape[0] // 10))
+if test_samples >= song_windows.shape[0]:
+    test_samples = song_windows.shape[0] - 1
+
+x_test = song_windows[:test_samples]
+y_test = intensity_targets[:test_samples]
+
+train_inputs = song_windows[test_samples:]
+train_targets = intensity_targets[test_samples:]
+
+if train_inputs.shape[0] < 2:
+    raise RuntimeError("Not enough samples available for training after test split.")
+
+split_idx = int(train_inputs.shape[0] * 0.85)
+if split_idx <= 0:
+    split_idx = 1
+if split_idx >= train_inputs.shape[0]:
+    split_idx = train_inputs.shape[0] - 1
+
+x_train = train_inputs[:split_idx]
+y_train = train_targets[:split_idx]
+x_val = train_inputs[split_idx:]
+y_val = train_targets[split_idx:]
+
+# Build or load model
+date_time = datetime.now()
+timestamp = f"{date_time.month}_{date_time.day}__{date_time.hour}_{date_time.minute}"
+save_model_name = f"tf_model_intensity_{timestamp}.h5"
+
+intensity_model, save_model_name = load_keras_model(save_model_name)
+if intensity_model is None:
+    input_shape = [x_train.shape[1:]]
+    intensity_model = create_keras_model('intensity_cnn', input_shape, 1)
+    adam = Adam(learning_rate=learning_rate, weight_decay=learning_rate / max(1, n_epochs))
+    intensity_model.compile(loss='mean_squared_error', optimizer=adam, metrics=['mae'])
+
+intensity_model.summary()
+
+# Train model
+intensity_model.fit(
+    x=x_train,
+    y=y_train,
+    validation_data=(x_val, y_val),
+    epochs=n_epochs,
+    batch_size=batch_size,
+    shuffle=True,
+    verbose=1,
+)
+
+# Evaluate model
+print("\nEvaluating test data...")
+eval_results = intensity_model.evaluate(x_test, y_test, verbose=1)
+print(f"Test loss: {eval_results[0]:.4f}, test MAE: {eval_results[1]:.4f}")
+
+# Save model
+model_path = paths.model_path + save_model_name
+print(f"Saving model at: {model_path}")
+intensity_model.save(model_path)
+
+print("\nFinished Training")


### PR DESCRIPTION
## Summary
- add preprocessing helper to build beat intensity targets aligned with 2s spectrogram windows
- extend the TensorFlow model factory with a CNN-based intensity regressor and expose new training configuration knobs
- introduce a dedicated training script that prepares the dataset, trains, evaluates, and saves the beat intensity model

## Testing
- python -m compileall preprocessing/intensity_pre.py training/train_intensity.py training/tensorflow_models.py

------
https://chatgpt.com/codex/tasks/task_e_68d848c16e38832798d85916701e573a