### PR TITLE
Add intensity inference and dynamic speed adaptation

### DIFF
--- a/map_creation/gen_beats.py
+++ b/map_creation/gen_beats.py
@@ -11,6 +11,7 @@ from beat_prediction.beat_prop import get_beat_prop, tcn_reshape
 from map_creation.sanity_check import *
 # from map_creation.class_helpers import *
 from map_creation.map_creator import create_map
+from map_creation.intensity_inference import compute_dynamic_speed_factors
 from map_creation.find_bpm import get_file_bpm
 from map_creation.bpm_optimizer import align_beats_on_bpm
 
@@ -66,6 +67,9 @@ def main(name_ar: list, debug_beats=False) -> bool:
     if len(name_ar) > 1:
         print("Multi-core song generation currently not implemented!")
         exit()
+
+    # reset dynamic speed factors for every run
+    config.dynamic_speed_factors = None
 
     # update configuration
     if config.add_silence_flag:
@@ -233,6 +237,17 @@ def main(name_ar: list, debug_beats=False) -> bool:
         # timing_ar = np.delete(timing_ar, rm_idx)  # not working/unused
         map_times = np.delete(map_times, rm_idx)
 
+    dynamic_speed_factors = None
+    if config.use_intensity_model and song_ar and len(song_ar[0]) > 0:
+        dynamic_speed_factors = compute_dynamic_speed_factors(song_ar[0])
+        if dynamic_speed_factors is not None and len(dynamic_speed_factors) != len(map_times):
+            if config.verbose_level > 0:
+                print(
+                    "Warning: Intensity predictions did not align with beat times. "
+                    "Skipping dynamic speed adaptation."
+                )
+            dynamic_speed_factors = None
+
     # Load pretrained encoder model
     model_path = get_full_model_path(config.enc_version)
     enc_model = load_model(model_path)
@@ -252,7 +267,21 @@ def main(name_ar: list, debug_beats=False) -> bool:
     ############
     # TODO: replace with default content instead of deletion
     map_times = map_times[config.lstm_len:]     # required by lstm start-up
+    if dynamic_speed_factors is not None:
+        if len(dynamic_speed_factors) <= config.lstm_len:
+            dynamic_speed_factors = None
+        else:
+            dynamic_speed_factors = dynamic_speed_factors[config.lstm_len:]
+
     map_times = map_times[:len(y_class_map)]    # rest from sectioning into lstm len batches
+    if dynamic_speed_factors is not None:
+        if len(dynamic_speed_factors) >= len(y_class_map):
+            dynamic_speed_factors = dynamic_speed_factors[:len(y_class_map)]
+        else:
+            dynamic_speed_factors = None
+
+    if dynamic_speed_factors is not None:
+        config.dynamic_speed_factors = dynamic_speed_factors
 
     ############
     # add events
@@ -275,8 +304,11 @@ def main(name_ar: list, debug_beats=False) -> bool:
         create_map_depr(y_class_map, map_times, events, name_ar[0], bpm,
                         pitch_input[-1], pitch_times[-1])
     else:
-        create_map(y_class_map, map_times, events, name_ar[0], bpm,
-                   pitch_input[-1], pitch_times[-1])
+        try:
+            create_map(y_class_map, map_times, events, name_ar[0], bpm,
+                       pitch_input[-1], pitch_times[-1])
+        finally:
+            config.dynamic_speed_factors = None
 
     return False  # success
 

--- a/map_creation/intensity_inference.py
+++ b/map_creation/intensity_inference.py
@@ -1,0 +1,86 @@
+"""Inference helpers for the beat intensity model."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+import numpy as np
+from keras.models import load_model
+
+from tools.config import get_config
+from tools.config.mapper_selection import get_full_model_path
+
+config = get_config()
+
+
+@lru_cache(maxsize=1)
+def _load_intensity_model():
+    """Load and cache the trained intensity model."""
+
+    try:
+        model_path = get_full_model_path(config.intensity_model_version)
+    except FileNotFoundError:
+        if config.verbose_level > 0:
+            print(
+                "Warning: Could not locate the beat intensity model. "
+                "Dynamic speed adaptation will be skipped."
+            )
+        return None
+
+    return load_model(model_path)
+
+
+def _smooth_series(values: np.ndarray, window: int) -> np.ndarray:
+    """Apply a simple moving average with edge padding."""
+
+    if window <= 1:
+        return values
+
+    window = int(window)
+    if window % 2 == 0:
+        window += 1
+
+    kernel = np.ones(window, dtype=np.float32) / float(window)
+    pad = window // 2
+    padded = np.pad(values, (pad, pad), mode="edge")
+    smoothed = np.convolve(padded, kernel, mode="valid")
+    return smoothed.astype(np.float32)
+
+
+def predict_intensity_ratios(song_windows: np.ndarray) -> Optional[np.ndarray]:
+    """Predict beat intensity ratios for the provided spectrogram windows."""
+
+    model = _load_intensity_model()
+    if model is None:
+        return None
+
+    if song_windows.size == 0:
+        return np.zeros((0,), dtype=np.float32)
+
+    predictions = model.predict(song_windows, verbose=0).reshape(-1)
+    return predictions.astype(np.float32)
+
+
+def compute_dynamic_speed_factors(song_windows: np.ndarray) -> Optional[np.ndarray]:
+    """Return per-sample speed factors inferred from the intensity model."""
+
+    if not config.use_intensity_model:
+        return None
+
+    ratios = predict_intensity_ratios(song_windows)
+    if ratios is None:
+        return None
+
+    ratios = np.nan_to_num(ratios, nan=1.0, posinf=1.0, neginf=1.0)
+    scaled = 1.0 + (ratios - 1.0) * float(config.intensity_response)
+    smoothed = _smooth_series(scaled.astype(np.float32), int(config.intensity_smoothing))
+    clipped = np.clip(smoothed, config.intensity_speed_min, config.intensity_speed_max)
+    return clipped.astype(np.float32)
+
+
+__all__ = [
+    "compute_dynamic_speed_factors",
+    "predict_intensity_ratios",
+]
+

--- a/map_creation/sanity_check.py
+++ b/map_creation/sanity_check.py
@@ -938,6 +938,13 @@ def correct_notes(notes, timings):
     last_time = 0
     rm_counter = 0
 
+    dynamic_factors = getattr(config, "dynamic_speed_factors", None)
+    if dynamic_factors is not None:
+        dynamic_factors = np.asarray(dynamic_factors, dtype=np.float32)
+        dynamic_len = len(dynamic_factors)
+    else:
+        dynamic_len = 0
+
     # reduce note difficulty at start and end of song
     se_idx = config.decr_speed_range  # start_end_index
     # compensate quick start behavior
@@ -965,10 +972,14 @@ def correct_notes(notes, timings):
             speed = calc_note_speed(nl_last, notes[idx], new_time - last_time)
 
             # remove too fast elements
+            base_speed = config.max_speed
+            if dynamic_factors is not None and idx < dynamic_len:
+                base_speed = config.max_speed * float(dynamic_factors[idx])
+
             if idx in decrease_range:
-                mx_speed = config.max_speed * decrease_val[idx]
+                mx_speed = base_speed * decrease_val[idx]
             else:
-                mx_speed = config.max_speed
+                mx_speed = base_speed
 
             factor = get_factor_from_max_speed(mx_speed, 0.5, 1)
             mx_speed *= factor

--- a/tools/config/config.py
+++ b/tools/config/config.py
@@ -206,6 +206,12 @@ class Config:
         self.intensity_batch_size = 128
         self.intensity_test_samples = 350
         self.intensity_song_limit = 240
+        self.use_intensity_model = True
+        self.intensity_model_version = 'tf_model_intensity_'
+        self.intensity_speed_min = 0.75
+        self.intensity_speed_max = 1.30
+        self.intensity_response = 0.65
+        self.intensity_smoothing = 5
 
         # Event prediction model configuration
         self.event_learning_rate = 1e-3
@@ -222,6 +228,7 @@ class Config:
         self.obstacle_time_gap_orig = self.obstacle_time_gap
         self.thresh_beat_orig = self.thresh_beat
         self.thresh_onbeat_orig = self.thresh_onbeat
+        self.dynamic_speed_factors = None
 
 
 _CONFIG_INSTANCE = Config()


### PR DESCRIPTION
## Summary
- add an intensity model inference helper that produces smoothed per-sample speed factors
- integrate intensity-driven speed scaling into the beat generation pipeline and note sanity checks
- expose configuration switches for the intensity model and dynamic speed behaviour

## Testing
- pytest tests/test_config_implementation.py

------
https://chatgpt.com/codex/tasks/task_e_68d9011dabec832786791106633050d4