### PR TITLE
Preserve song metadata across conversion and map info

### DIFF
--- a/bs_shift/export_map.py
+++ b/bs_shift/export_map.py
@@ -1,8 +1,10 @@
-import shutil
 import os
+import shutil
+
 from pydub import AudioSegment, effects
 
 from tools.config import config, paths
+from tools.utils.song_metadata import extract_metadata, metadata_to_tags, save_metadata
 
 
 def shutil_copy_maps(song_name, index="1234_"):
@@ -18,23 +20,29 @@ def shutil_copy_maps(song_name, index="1234_"):
 
 def check_music_files(files, dir_path):
     song_list = []
+    metadata_for_song = {}
     for file_name in files:
-        ending = file_name.split('.')[-1]
+        ending = file_name.split('.')[-1].lower()
         # if ending in ['mp3', 'mp4', 'm4a', 'wav', 'aac', 'flv', 'wma']:   # (TODO: test more music formats)
         if ending in ['mp3', 'mp4', 'm4a']:   # (TODO: test more music formats)
         # if ending in ['NOT_WORKING!']:
             # convert music to ogg format
             output_file = f"{file_name[:-4]}.egg"
-            convert_music_file(dir_path + file_name, dir_path + output_file)
+            source_path = dir_path + file_name
+            metadata_for_song[output_file] = extract_metadata(source_path)
+            convert_music_file(source_path, dir_path + output_file,
+                               metadata=metadata_for_song[output_file])
             os.remove(dir_path + file_name)
             song_list.append(output_file)
         elif ending in ['ogg']:
             source = dir_path + file_name
             destination = dir_path + file_name.replace('.ogg', '.egg')
+            metadata_for_song[file_name.replace('.ogg', '.egg')] = extract_metadata(source)
             shutil.move(source, destination)
             song_list.append(file_name.replace('.ogg', '.egg'))
         elif ending in ['egg']:
             song_list.append(file_name)
+            metadata_for_song[file_name] = extract_metadata(dir_path + file_name)
         else:
             print(f"Warning: Can not read {file_name} as music file.")
             pass
@@ -49,6 +57,7 @@ def check_music_files(files, dir_path):
             new_name = f"{new_name[:-5]}.egg"
         if new_name != song_name:
             shutil.move(dir_path + song_name, dir_path + new_name)
+            metadata_for_song[new_name] = metadata_for_song.pop(song_name, {})
             song_list[idx] = new_name
 
     # Normalize the volume for each song in advance
@@ -75,12 +84,22 @@ def check_music_files(files, dir_path):
                         print(f"Warning: Maximum iterations for normalizing song exceeded: {song_name}. Continue")
                         break
 
-                normalized_song.export(dir_path + song_name, format="ogg")
+                tags = metadata_to_tags(metadata_for_song.get(song_name))
+                normalized_song.export(dir_path + song_name, format="ogg", tags=tags)
                 print(f"Normalized volume of song: {song_name} with new RMS: {normalized_song.rms/1e9:.2f}")
+            else:
+                # ensure metadata is kept even if no normalization is needed
+                metadata_for_song[song_name] = metadata_for_song.get(song_name, {})
+
+    for song_name in song_list:
+        metadata = metadata_for_song.get(song_name)
+        if metadata is None:
+            metadata = extract_metadata(dir_path + song_name)
+        save_metadata(song_name[:-4], metadata)
     return song_list
 
 
-def convert_music_file(file_name, output_file):
+def convert_music_file(file_name, output_file, metadata=None):
     # Load the mp3 file
     m_format = file_name.split('.')[-1]
     if m_format == 'egg':
@@ -90,10 +109,11 @@ def convert_music_file(file_name, output_file):
     output_file_format = output_file.split('.')[-1]
 
     # Export the audio as ogg file
+    tags = metadata_to_tags(metadata)
     if output_file_format == 'ogg' or output_file_format == 'egg':
-        audio.export(output_file, format="ogg")
+        audio.export(output_file, format="ogg", tags=tags)
     elif output_file_format == 'mp3':
-        audio.export(output_file, format="mp3")
+        audio.export(output_file, format="mp3", tags=tags)
     else:
         print(f"Error in music converter: Format unknown: {m_format}")
         exit()

--- a/map_creation/map_creator.py
+++ b/map_creation/map_creator.py
@@ -11,6 +11,7 @@ from map_creation.gen_obstacles import calculate_obstacles
 from map_creation.gen_sliders import calculate_sliders
 from map_creation.artificial_mod import gimme_more_notes
 from tools.config import config, paths
+from tools.utils.song_metadata import load_metadata
 
 
 def create_map(y_class_num, timings, events, name, bpm, pitch_input, pitch_times):
@@ -339,50 +340,56 @@ def get_info_map_string(name, bpm, bs_diff):
                     break
                 last_abs = abs_diff
 
-    info_string = '{\n'
-    info_string += '"_version": "2.0.0",\n'
-    info_string += f'"_songName": "{name}",\n'
-    info_string += f'"_songSubName": "Diff_{diff_plus / 4:.1f}",\n'
-    info_string += '"_songAuthorName": "unknown",\n'
-    info_string += '"_levelAuthorName": "InfernoSaber",\n'
-    info_string += f'"_beatsPerMinute": {bpm},\n'
-    info_string += '"_songTimeOffset": 0,\n'
-    info_string += '"_shuffle": 0,\n'
-    info_string += '"_shufflePeriod": 0.5,\n'
-    info_string += '"_previewStartTime": 10,\n'
-    info_string += '"_previewDuration": 20,\n'
-    info_string += f'"_songFilename": "{name}.egg",\n'
-    info_string += '"_coverImageFilename": "cover.jpg",\n'
-    info_string += '"_environmentName": "DefaultEnvironment",\n'
-    info_string += '"_allDirectionsEnvironmentName": "GlassDesertEnvironment",\n'
-    info_string += '"_difficultyBeatmapSets": ['
-    info_string += '{\n'
-    info_string += '"_beatmapCharacteristicName": "Standard",\n'
-    info_string += '"_difficultyBeatmaps": [\n'
+    jump_speed = [float(js) for js in jump_speed]
+    jsb_offset = [float(round(offset, 2)) for offset in jsb_offset]
 
+    metadata = load_metadata(name)
+    song_title = metadata.get('title', name)
+    song_author = metadata.get('artist', 'unknown')
+    song_sub_name = metadata.get('album', f'Diff_{diff_plus / 4:.1f}')
+
+    beatmaps = []
     for i, diff in enumerate(diff_list):
-        info_string += '{\n'
-        info_string += f'"_difficulty": "{diff}",\n'
-        if diff == 'Expert':
-            info_string += '"_difficultyRank": 7,\n'
-        else:
-            info_string += '"_difficultyRank": 9,\n'
-        info_string += f'"_beatmapFilename": "{diff}.dat",\n'
-        info_string += f'"_noteJumpMovementSpeed": {jump_speed[i]},\n'
-        info_string += f'"_noteJumpStartBeatOffset": {jsb_offset[i]:.2f}\n'
-        if i + 1 < len(diff_list):
-            info_string += '},\n'
-        else:
-            info_string += '}\n'
+        beatmaps.append({
+            "_difficulty": diff,
+            "_difficultyRank": 7 if diff == 'Expert' else 9,
+            "_beatmapFilename": f"{diff}.dat",
+            "_noteJumpMovementSpeed": jump_speed[i],
+            "_noteJumpStartBeatOffset": jsb_offset[i],
+        })
 
-    info_string += ']}],\n'
-    info_string += ('"_customData": {"_editors": {"_lastEditedBy": '
-                    '"InfernoSaber", "InfernoSaber": {"version": "'
-                    f"{config.InfernoSaber_version}"
-                    '"}}}\n')
-    info_string += '}\n'
+    editors = {
+        "_lastEditedBy": "InfernoSaber",
+        "InfernoSaber": {"version": f"{config.InfernoSaber_version}"}
+    }
+    custom_data = {"_editors": editors}
+    if metadata:
+        custom_data["_songMetadata"] = metadata
 
-    return info_string
+    info_data = {
+        "_version": "2.0.0",
+        "_songName": song_title,
+        "_songSubName": song_sub_name,
+        "_songAuthorName": song_author,
+        "_levelAuthorName": "InfernoSaber",
+        "_beatsPerMinute": float(bpm),
+        "_songTimeOffset": 0,
+        "_shuffle": 0,
+        "_shufflePeriod": 0.5,
+        "_previewStartTime": 10,
+        "_previewDuration": 20,
+        "_songFilename": f"{name}.egg",
+        "_coverImageFilename": "cover.jpg",
+        "_environmentName": "DefaultEnvironment",
+        "_allDirectionsEnvironmentName": "GlassDesertEnvironment",
+        "_difficultyBeatmapSets": [{
+            "_beatmapCharacteristicName": "Standard",
+            "_difficultyBeatmaps": beatmaps,
+        }],
+        "_customData": custom_data,
+    }
+
+    return json.dumps(info_data, indent=2) + '\n'
 
 # {
 #   "_version": "2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ huggingface-hub~=0.29.3
 requests~=2.32.3
 gradio~=5.29.1
 yt-dlp
+mutagen

--- a/tools/utils/song_metadata.py
+++ b/tools/utils/song_metadata.py
@@ -1,0 +1,103 @@
+"""Utilities for extracting and storing song metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Optional
+
+from tools.config import paths
+
+try:
+    from mutagen import File as MutagenFile
+except ImportError:  # pragma: no cover - gracefully handle optional dependency
+    MutagenFile = None
+
+
+_METADATA_KEYS = ("title", "artist", "album", "genre")
+
+
+def _sanitize_metadata(metadata: Dict[str, Optional[str]]) -> Dict[str, str]:
+    """Return a copy of *metadata* with falsy entries removed and values cast to strings."""
+
+    if not metadata:
+        return {}
+
+    sanitized: Dict[str, str] = {}
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple)):
+            if not value:
+                continue
+            value = value[0]
+        text = str(value).strip()
+        if text:
+            sanitized[key] = text
+    return sanitized
+
+
+def extract_metadata(file_path: str) -> Dict[str, str]:
+    """Extract metadata from *file_path* if possible.
+
+    Returns an empty dictionary if the metadata cannot be read or the dependency is missing.
+    """
+
+    if MutagenFile is None:
+        return {}
+
+    try:
+        audio = MutagenFile(file_path, easy=True)
+    except Exception:
+        return {}
+
+    if not audio or not getattr(audio, "tags", None):
+        return {}
+
+    metadata: Dict[str, Optional[str]] = {}
+    for key in _METADATA_KEYS:
+        value = audio.tags.get(key)
+        if value:
+            metadata[key] = value
+
+    return _sanitize_metadata(metadata)
+
+
+def save_metadata(name: str, metadata: Dict[str, Optional[str]]) -> None:
+    """Persist *metadata* for the song *name* (without extension)."""
+
+    sanitized = _sanitize_metadata(metadata)
+    metadata_path = os.path.join(paths.song_data, f"{name}.json")
+
+    if sanitized:
+        os.makedirs(paths.song_data, exist_ok=True)
+        with open(metadata_path, "w", encoding="utf-8") as file:
+            json.dump(sanitized, file, ensure_ascii=False, indent=2)
+    elif os.path.exists(metadata_path):
+        os.remove(metadata_path)
+
+
+def load_metadata(name: str) -> Dict[str, str]:
+    """Load persisted metadata for the song *name* (without extension)."""
+
+    metadata_path = os.path.join(paths.song_data, f"{name}.json")
+    if not os.path.isfile(metadata_path):
+        return {}
+
+    try:
+        with open(metadata_path, "r", encoding="utf-8") as file:
+            data = json.load(file)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    return _sanitize_metadata(data)
+
+
+def metadata_to_tags(metadata: Dict[str, Optional[str]] | None) -> Optional[Dict[str, str]]:
+    """Prepare *metadata* for embedding into an audio file."""
+
+    return _sanitize_metadata(metadata or {}) or None
+


### PR DESCRIPTION
## Summary
- add helper utilities to extract, persist, and reload song metadata from audio files
- preserve audio tags during import/normalization and store metadata alongside each track
- populate info.dat with extracted song metadata so the generated maps reflect the source title and author

## Testing
- python -m compileall tools/utils/song_metadata.py bs_shift/export_map.py map_creation/map_creator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691248d4bdfc8327a074e88b19e399e4)