### PR TITLE
Add filename fallback for song metadata extraction

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = tests/test_*.py
+addopts = -ra

--- a/tests/test_song_metadata.py
+++ b/tests/test_song_metadata.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import importlib
+import pytest
+
+from tools.config import config
+
+
+def reload_module():
+    module = importlib.import_module("tools.utils.song_metadata")
+    return importlib.reload(module)
+
+
+def test_extract_metadata_prefers_audio_tags(monkeypatch):
+    module = reload_module()
+
+    class DummyAudio:
+        tags = {
+            "title": ["Some Title"],
+            "artist": ["Some Artist"],
+            "genre": ["Electronic"],
+        }
+
+    monkeypatch.setattr(module, "MutagenFile", lambda *_args, **_kwargs: DummyAudio())
+
+    metadata = module.extract_metadata("ignored.mp3")
+    assert metadata == {
+        "title": "Some Title",
+        "artist": "Some Artist",
+        "genre": "Electronic",
+    }
+
+
+def test_extract_metadata_fallbacks_to_filename(monkeypatch):
+    module = reload_module()
+
+    class DummyAudio:
+        tags = {}
+
+    monkeypatch.setattr(module, "MutagenFile", lambda *_args, **_kwargs: DummyAudio())
+
+    metadata = module.extract_metadata("Artist Name - Song Title.ogg")
+    assert metadata == {"artist": "Artist Name", "title": "Song Title"}
+
+
+def test_extract_metadata_without_mutagen(monkeypatch):
+    module = reload_module()
+    monkeypatch.setattr(module, "MutagenFile", None)
+
+    metadata = module.extract_metadata("Other Artist - Other Song.flac")
+    assert metadata == {"artist": "Other Artist", "title": "Other Song"}
+
+
+def test_extract_metadata_returns_empty_when_no_match(monkeypatch):
+    module = reload_module()
+
+    class DummyAudio:
+        tags = {}
+
+    monkeypatch.setattr(module, "MutagenFile", lambda *_args, **_kwargs: DummyAudio())
+
+    with monkeypatch.context() as m:
+        m.setattr(config, "metadata_naming_convention", "{artist} - {title}")
+        metadata = module.extract_metadata("NotMatchingFilename.mp3")
+
+    assert metadata == {}

--- a/tools/utils/song_metadata.py
+++ b/tools/utils/song_metadata.py
@@ -39,29 +39,59 @@ def _sanitize_metadata(metadata: Dict[str, Optional[str]]) -> Dict[str, str]:
     return sanitized
 
 
+def _metadata_from_filename(file_path: str) -> Dict[str, str]:
+    """Attempt to derive song metadata from *file_path* using configured conventions."""
+
+    if not getattr(config, "enable_auto_metadata", False):
+        return {}
+
+    convention = getattr(config, "metadata_naming_convention", "")
+    if not convention or "{artist}" not in convention or "{title}" not in convention:
+        return {}
+
+    filename = Path(file_path).stem
+
+    pattern = re.escape(convention)
+    pattern = pattern.replace(r"\{artist\}", r"(?P<artist>.+?)")
+    pattern = pattern.replace(r"\{title\}", r"(?P<title>.+?)")
+
+    match = re.fullmatch(pattern, filename)
+    if not match:
+        return {}
+
+    metadata: Dict[str, Optional[str]] = {
+        key: (value.strip() if value is not None else value)
+        for key, value in match.groupdict().items()
+    }
+    return _sanitize_metadata(metadata)
+
+
 def extract_metadata(file_path: str) -> Dict[str, str]:
     """Extract metadata from *file_path* if possible.
 
-    Returns an empty dictionary if the metadata cannot be read or the dependency is missing.
+    Returns an empty dictionary if the metadata cannot be read and the filename does not
+    match the configured metadata naming convention.
     """
-    if MutagenFile is None:
-        return {}
-
-    try:
-        audio = MutagenFile(file_path, easy=True)
-    except Exception:
-        return {}
-
-    if not audio or not getattr(audio, "tags", None):
-        return {}
 
     metadata: Dict[str, Optional[str]] = {}
-    for key in _METADATA_KEYS:
-        value = audio.tags.get(key)
-        if value:
-            metadata[key] = value
 
-    return _sanitize_metadata(metadata)
+    if MutagenFile is not None:
+        try:
+            audio = MutagenFile(file_path, easy=True)
+        except Exception:
+            audio = None
+
+        if audio and getattr(audio, "tags", None):
+            for key in _METADATA_KEYS:
+                value = audio.tags.get(key)
+                if value:
+                    metadata[key] = value
+
+    sanitized = _sanitize_metadata(metadata)
+    if sanitized:
+        return sanitized
+
+    return _metadata_from_filename(file_path)
 
 
 def save_metadata(name: str, metadata: Dict[str, Optional[str]]) -> None:


### PR DESCRIPTION
## Summary
- add a filename-based fallback to populate song metadata when audio tags are missing
- add tests covering audio tags, filename fallback, and unmatched filenames while configuring pytest discovery

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913a8a65ef083278ad69720a6cbadb3)