### PR TITLE
Handle reinstall-required releases

### DIFF
--- a/main_app.py
+++ b/main_app.py
@@ -38,15 +38,28 @@ def check_for_updates():
 
             response = requests.get(github_url)
             latest_version = response.json()[0]['tag_name']
+            requires_reinstall = latest_version.endswith('-reinstall')
+            latest_display_version = latest_version[:-len('-reinstall')] if requires_reinstall else latest_version
             current_version = f"v{config.InfernoSaber_version}"
+            current_display_version = f"v{config.get_clean_version()}"
+
             if latest_version != current_version:
-                update_check_response = (
-                    f"Version <{latest_version}> is released! Your version is <{config.InfernoSaber_version}>. "
-                    f"Please update with the Pinokio Update function on the left.")
-                return (f"Version <{latest_version}> is released! Your version is <{config.InfernoSaber_version}>. "
-                        f"Please update with the Pinokio Update function on the left.")
-            update_check_response = f"You are up to date ({latest_version})"
-            return f"You are up to date ({latest_version})"
+                if requires_reinstall:
+                    update_check_response = (
+                        f"Version <{latest_display_version}> requires a full reinstall. "
+                        f"Your version is <{current_display_version}>. "
+                        "Please delete your existing InfernoSaber installation and reinstall via the Pinokio installer."
+                    )
+                else:
+                    update_check_response = (
+                        f"Version <{latest_display_version}> is released! "
+                        f"Your version is <{current_display_version}>. "
+                        "Please update with the Pinokio Update function on the left."
+                    )
+                return update_check_response
+
+            update_check_response = f"You are up to date ({latest_display_version})"
+            return update_check_response
 
         else:
             return update_check_response

--- a/map_creation/map_creator.py
+++ b/map_creation/map_creator.py
@@ -360,7 +360,7 @@ def get_info_map_string(name, bpm, bs_diff):
 
     editors = {
         "_lastEditedBy": "InfernoSaber",
-        "InfernoSaber": {"version": f"{config.InfernoSaber_version}"}
+        "InfernoSaber": {"version": config.get_clean_version()}
     }
     custom_data = {"_editors": editors}
     if metadata:

--- a/map_creation/map_creator_deprecated.py
+++ b/map_creation/map_creator_deprecated.py
@@ -313,7 +313,7 @@ def get_info_map_string(name, bpm, bs_diff):
     info_string += ']}],\n'
     info_string += ('"_customData": {"_editors": {"_lastEditedBy": '
                     '"InfernoSaber", "InfernoSaber": {"version": "'
-                    f"{config.InfernoSaber_version}"
+                    f"{config.get_clean_version()}"
                     '"}}}\n')
     info_string += '}\n'
 

--- a/tools/config/config.py
+++ b/tools/config/config.py
@@ -1,12 +1,24 @@
 import numpy as np
+from typing import Optional
 
 # from map_creation.sanity_check import improve_timings
 
 ########################################
-# config file for all important values 
+# config file for all important values
 # used in multiple codes
 ########################################
-InfernoSaber_version = "1.7.2.app1"  # coded into the info.dat file
+InfernoSaber_version = "1.7.2.app1-reinstall"  # coded into the info.dat file
+
+
+def get_clean_version(version: Optional[str] = None) -> str:
+    """Return ``version`` without any reinstall flag suffix."""
+
+    suffix = "-reinstall"
+    if version is None:
+        version = InfernoSaber_version
+    if version.endswith(suffix):
+        return version[: -len(suffix)]
+    return version
 bs_mapping_version = "v3"  # allows to generate advanced features like arcs
 # bs_mapping_version = "v2"  # legacy mode, may be deprecated in future
 


### PR DESCRIPTION
## Summary
- append the reinstall flag to the app version and provide a helper for the cleaned value
- warn via the update checker when a reinstall-only release is detected
- ensure generated info.dat files store the clean InfernoSaber version without the reinstall flag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916339455c48327b700bdc64836047c)